### PR TITLE
Hosts file support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+man/hostmux.1: hostmux.mandoc
+	mandoc -Tman hostmux.mandoc > man/hostmux.1

--- a/hostmux
+++ b/hostmux
@@ -19,10 +19,10 @@ s)     SESSION_NAME=$OPTARG
        ;;
 l)     LAYOUT=$OPTARG
        ;;
+f)     HOSTS_FILE=$OPTARG
+       ;;
 h)     echo $USAGE
        exit 1
-       ;;
-f)     HOSTS_FILE=$OPTARG
        ;;
 '?')   echo "$0: invalid option -$OPTARG" >&2
        echo $USAGE >&2

--- a/hostmux
+++ b/hostmux
@@ -12,7 +12,7 @@ SESSION_NAME=hostmux
 LAYOUT=even-vertical
 
 # Get optional user settings
-while getopts :s:l:h opt
+while getopts :s:l:f:h opt
 do
 case $opt in
 s)     SESSION_NAME=$OPTARG
@@ -21,6 +21,8 @@ l)     LAYOUT=$OPTARG
        ;;
 h)     echo $USAGE
        exit 1
+       ;;
+f)     HOSTS_FILE=$OPTARG
        ;;
 '?')   echo "$0: invalid option -$OPTARG" >&2
        echo $USAGE >&2
@@ -33,13 +35,32 @@ echo $#
 echo $LAYOUT
 
 # The actual script
-NUMBER_OF_HOSTS=$#
+NUMBER_OF_HOSTS=0
+NUMBER_OF_HOST_ARGS=$#
+HOSTS=""
+
+while [ $NUMBER_OF_HOSTS -lt $NUMBER_OF_HOST_ARGS ]
+do
+  HOSTS="$HOSTS$1 "
+  NUMBER_OF_HOSTS=$(($NUMBER_OF_HOSTS+1))
+  shift
+done
+
+if [ -n "$HOSTS_FILE" ]
+then
+  echo "parsing hosts file $HOSTS_FILE"
+  while read line
+  do
+    HOSTS="$HOSTS$line "
+    NUMBER_OF_HOSTS=$(($NUMBER_OF_HOSTS+1))
+  done < "$HOSTS_FILE"
+fi
 
 # Initialize Session
 tmux -2 new-session -d -s $SESSION_NAME
 
 
-# Split as many times as we have hosts as arguments and reset
+# Split as many times as we have hosts and reset
 # the layout each time for even distribution
 LOOP_INDEX=1
 
@@ -57,13 +78,11 @@ done
 # into next iteration. Now $1 refers to the next argument passed
 # to the script
 PANE_INDEX=0
-PANE_MAX=$(($NUMBER_OF_HOSTS-1))
 
-while [ $PANE_INDEX -le $PANE_MAX ]
+for host in $HOSTS
 do
-  tmux send-keys -t $PANE_INDEX "ssh $1" C-m
+  tmux send-keys -t $PANE_INDEX "ssh $host" C-m
 
-  shift
   PANE_INDEX=$(($PANE_INDEX+1))
 done
 

--- a/hostmux
+++ b/hostmux
@@ -39,6 +39,7 @@ NUMBER_OF_HOSTS=0
 NUMBER_OF_HOST_ARGS=$#
 HOSTS=""
 
+# Add each remaining host argument to the HOSTS list
 while [ $NUMBER_OF_HOSTS -lt $NUMBER_OF_HOST_ARGS ]
 do
   HOSTS="$HOSTS$1 "
@@ -46,6 +47,7 @@ do
   shift
 done
 
+# add each line in the HOSTS_FILE to the HOSTS list
 if [ -n "$HOSTS_FILE" ]
 then
   echo "parsing hosts file $HOSTS_FILE"

--- a/hostmux.mandoc
+++ b/hostmux.mandoc
@@ -8,6 +8,7 @@
 .Nm
 .Op Fl s Ar session-name
 .Op Fl l Ar tmux-layout
+.Op Fl f Ar hosts-file
 .Op Fl h
 .Op Ar host_a
 .Op Ar host_b
@@ -31,6 +32,9 @@ specify unique names for your sessions
 Specify a valid tmux layout e.g. even-horizontal, tiled, etc. It defaults
 to
 .Ql even-vertical
+.It Fl f
+Specify a file to read ssh targets from. This can be used in addition to
+host specified as arguments on the command line.
 .It Fl h
 Display usage information
 .It Ar host
@@ -39,6 +43,10 @@ is what you would pass to the ssh command when you are connecting
 to a host. Currently there is no support for passing additional flags
 to ssh. If you do need them, add them to your ~/.ssh/config
 .El
+.Sh HOSTS FILE FORMAT
+The hosts file should contain one ssh target per line. The format and
+restrictiona sfor ssh targets are identical to those for hosts specified
+on the command line.
 .Sh SEE ALSO
 .Bl -tag -width Ds
 .It Xr tmux 1

--- a/zsh-completion/_hostmux
+++ b/zsh-completion/_hostmux
@@ -5,6 +5,7 @@ typeset -A opt_args
 _arguments -C \
   '*-l[Layout]:layouts:->layouts' \
   '*-s[Session Name]' \
+  '*-f[Hosts file]:hosts file:_files' \
   '*:destinations:->destinations' \
 && ret=0
 


### PR DESCRIPTION
Add support for supplying a file containing a list of ssh targets. Can be useful if you need to connect to multiple fixed sets of hosts often. Like a list of DB servers and another list of dev machines for example.

Not sure if the changes play nice with the added stuff in the pane_index branch, but I'm also not quite sure what that intends to accomplish. Maybe a compromise can be found.

Also: I did not commit the built man page because this brings in OS dependent changes like the following which seems undesireable. Instead I suggest a simple Makefile to build the man page if desired.

```
-.TH "HOSTMUX" "1" "February 8, 2016" "Mac OS X 10.10" "General Commands Manual"
+.TH "HOSTMUX" "1" "February 8, 2016" "Linux 3.2.0-4-amd64" "General Commands Manual"
```
