### PR TITLE
Enum sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ DESCRIPTION
 
      -l      Specify a valid tmux layout e.g. even-horizontal, tiled, etc. It
              defaults to `even-vertical'
+             
+     -r      Specify a remote host used to jump to the hosts in a secured
+             environment.
+
+     -x      Close the pane and/or session automatically when the ssh session
+             session exits successfully
 
      -x      Close the pane and/or session automatically when the ssh session
              session closes successfully

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ DESCRIPTION
      -l      Specify a valid tmux layout e.g. even-horizontal, tiled, etc. It
              defaults to `even-vertical'
              
-     -r      Specify a remote host used to jump to the hosts in a secured
-             environment.
-
      -x      Close the pane and/or session automatically when the ssh session
              session exits successfully
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ DESCRIPTION
              defaults to `even-vertical'
              
      -x      Close the pane and/or session automatically when the ssh session
-             session exits successfully
-
-     -x      Close the pane and/or session automatically when the ssh session
              session closes successfully
 
      -h      Display usage information

--- a/hostmux
+++ b/hostmux
@@ -11,9 +11,10 @@ USAGE="hostmux [-h] [-x] [-l <tmux layout>] [-s <session name>] HOST A [, HOST B
 SESSION_NAME=hostmux
 LAYOUT=even-vertical
 CLOSE=
+ENUM=false
 
 # Get optional user settings
-while getopts :s:l:h:x opt
+while getopts :s:l:h:x:n opt
 do
 case $opt in
 s)     SESSION_NAME=$OPTARG
@@ -24,6 +25,8 @@ x)     CLOSE=" && exit"
        ;;
 h)     echo $USAGE
        exit 1
+       ;;
+n)     ENUM=true
        ;;
 '?')   echo "$0: invalid option -$OPTARG" >&2
        echo $USAGE >&2
@@ -38,6 +41,9 @@ echo $LAYOUT
 # The actual script
 NUMBER_OF_HOSTS=$#
 
+# enumerate the sessions so hostmux does not add hosts to a session with the same name
+# this is especially usefull if you use hostmux in shell aliases to have easy access to your clusters
+$ENUM && SESSION_NAME="$SESSION_NAME-$(tmux ls | grep $SESSION_NAME | wc -l)"
 # Initialize Session
 tmux -2 new-session -d -s $SESSION_NAME
 

--- a/hostmux
+++ b/hostmux
@@ -43,7 +43,20 @@ NUMBER_OF_HOSTS=$#
 
 # enumerate the sessions so hostmux does not add hosts to a session with the same name
 # this is especially usefull if you use hostmux in shell aliases to have easy access to your clusters
-$ENUM && SESSION_NAME="$SESSION_NAME-$(tmux ls | grep $SESSION_NAME | wc -l)"
+if $ENUM ; then
+  SESSION_BASE="$SESSION_NAME"
+  SESSION_COUNT=$(tmux ls | grep $SESSION_NAME | wc -l)
+  SESSION_NAME="${SESSION_BASE}-${SESSION_COUNT}"
+  LIMIT=50
+  i=0
+  while grep -q "$SESSION_NAME" <(tmux ls 2>&1)
+  do
+    SESSION_COUNT=$(($SESSION_COUNT+1))
+    SESSION_NAME="${SESSION_BASE}-${SESSION_COUNT}"
+    i=$(($i+1))
+    [ $i -ge $LIMIT ] && break
+  done
+fi
 # Initialize Session
 tmux -2 new-session -d -s $SESSION_NAME
 

--- a/hostmux
+++ b/hostmux
@@ -45,7 +45,7 @@ NUMBER_OF_HOSTS=$#
 # this is especially usefull if you use hostmux in shell aliases to have easy access to your clusters
 if $ENUM ; then
   SESSION_BASE="$SESSION_NAME"
-  SESSION_COUNT=$(tmux ls | grep $SESSION_NAME | wc -l)
+  SESSION_COUNT=$(tmux ls 2>/dev/null | grep $SESSION_NAME | wc -l)
   SESSION_NAME="${SESSION_BASE}-${SESSION_COUNT}"
   LIMIT=50
   i=0

--- a/hostmux.mandoc
+++ b/hostmux.mandoc
@@ -9,6 +9,7 @@
 .Op Fl s Ar session-name
 .Op Fl l Ar tmux-layout
 .Op Fl x
+.Op Fl n
 .Op Fl h
 .Op Ar host_a
 .Op Ar host_b
@@ -34,7 +35,10 @@ to
 .Ql even-vertical
 .It Fl x
 Close the pane and/or session automatically when the ssh session
-exits successfully
+session exits successfully.
+.It Fl n
+Enumerate the sessions so hostmux does not add hosts to a session with the same name.
+This is especially usefull if you use hostmux in shell aliases to have easy access to your clusters.
 .It Fl h
 Display usage information
 .It Ar host

--- a/hostmux.mandoc
+++ b/hostmux.mandoc
@@ -35,7 +35,7 @@ to
 .Ql even-vertical
 .It Fl x
 Close the pane and/or session automatically when the ssh session
-session exits successfully.
+exits successfully.
 .It Fl n
 Enumerate the sessions so hostmux does not add hosts to a session with the same name.
 This is especially usefull if you use hostmux in shell aliases to have easy access to your clusters.

--- a/zsh-completion/_hostmux
+++ b/zsh-completion/_hostmux
@@ -6,6 +6,7 @@ _arguments -C \
   '*-l[Layout]:layouts:->layouts' \
   '*-s[Session Name]' \
   '*-x[Auto close pane]' \
+  '*-n[Enumerate sessions]' \
   '*:destinations:->destinations' \
 && ret=0
 


### PR DESCRIPTION
Enumerate the sessions so hostmux does not add hosts to a session with the same name.
This is especially usefull if you use hostmux in shell aliases to have easy access to your clusters.
