### PR TITLE
Streamline installation instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ bind-key X kill-session
 ## Installing on OS X via Homebrew
 
 ```
-brew tap hukl/homebrew-tap
-brew install hostmux
+brew install hukl/tap/hostmux
 ```
 
 ## Installing the ZSH completion


### PR DESCRIPTION
The installation on OS X can be further streamlined to a single command. `brew install` is clever enough to auto-install the tap if it isn't locally available yet, but the formula is specified using its canonical name. If the tap is already there, it will just install the formula. (The convention for taps is that `<user>/<repo>` maps to the GitHub repository `<user>/homebrew-<repo>`; that's why `homebrew-` can be omitted.)

_PS: Greetings from a long-time Freak Show listener (since MM001); your praise of Homebrew in FS174 was a pleasure to listen to!_
