### PR TITLE
Fix getopts -h option.

### DIFF
--- a/hostmux
+++ b/hostmux
@@ -13,7 +13,7 @@ LAYOUT=even-vertical
 CLOSE=
 
 # Get optional user settings
-while getopts :s:l:h:x opt
+while getopts s:l:hx opt
 do
 case $opt in
 s)     SESSION_NAME=$OPTARG


### PR DESCRIPTION
-h wasn't working (on linux, using sh=dash), since "h:" was used (-h doesn't
take an argument). Also remove the leading ":" in order to not ignore command
line parsing errors: using -h produced an error but was actually ignored and
the script was started anyway.
