### PR TITLE
Add some tweaks to the Makefile to make it behave more like a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ src=hostmux.mandoc
 tgt=man/hostmux.1
 
 $(tgt): $(src)
-	mkdir -p $(shell dirname $(tgt))
-	mandoc -I os=sh -Tman $(src) > $(tgt)
+	mkdir -p $(shell dirname $@)
+	mandoc -I os=sh -Tman $< > $@ || { rm -f $@ ; exit 2 ; }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-src=hostmux.mandoc
-tgt=man/hostmux.1
-
-$(tgt): $(src)
-	mkdir -p $(shell dirname $@)
+# This target creates the manpage from its source file
+#
+# (1) Create target's directory if it doesn't exist
+# (2) create the target $@ from the first prerequisite $<
+#     The shell redirection creates the target file before `mandoc` is
+#     actually executed. To avoid working further with an empty target file
+#     it's removed in case of an error and make exits with an error code.
+man/hostmux.1: hostmux.mandoc
+	mkdir -p $(dir $@)
 	mandoc -I os=sh -Tman $< > $@ || { rm -f $@ ; exit 2 ; }


### PR DESCRIPTION
- use *make* variables
- remove empty target file in case of an error (the target file is
  created by the shell redirection before `mandoc` runs)