### PR TITLE
fix: host config file not working

### DIFF
--- a/hostmux
+++ b/hostmux
@@ -54,7 +54,7 @@ then
     do
         HOSTS="$HOSTS$line "
         NUMBER_OF_HOSTS=$(($NUMBER_OF_HOSTS+1))
-    done < hf
+    done < $HOSTS_FILE
 fi
 
 echo $HOSTS

--- a/zsh-completion/_hostmux
+++ b/zsh-completion/_hostmux
@@ -9,6 +9,7 @@ _arguments -C \
   '*-p[Set pane title to ssh hostname]' \
   '*-P[Set remote prompt to ssh hostname]' \
   '*-a[Sync panes]' \
+  '*-f[Use hostnames from file]:host file:_files'\
   '*:destinations:->destinations' \
 && ret=0
 


### PR DESCRIPTION
Fixes reading hosts_file from undefined variable "hf", if the "-f" is used.